### PR TITLE
allows to add doctypes to controll box

### DIFF
--- a/Src/Our.Umbraco.DocTypeGridEditor/Web/Controllers/DocTypeGridEditorApiController.cs
+++ b/Src/Our.Umbraco.DocTypeGridEditor/Web/Controllers/DocTypeGridEditorApiController.cs
@@ -40,6 +40,23 @@ namespace Our.Umbraco.DocTypeGridEditor.Web.Controllers
         }
 
         [System.Web.Http.HttpGet]
+        public object GetContentType([System.Web.Http.ModelBinding.ModelBinder] string alias)
+        {
+            var allContentTypes = Services.ContentTypeService.GetAllContentTypes();
+            var found = allContentTypes
+                .Where(o => o.Alias.Equals(alias, StringComparison.InvariantCultureIgnoreCase))
+                .Select(x => new
+                {
+                    id = x.Id,
+                    guid = x.Key,
+                    name = x.Name,
+                    alias = x.Alias,
+                    icon = x.Icon
+                });
+            return found.Any() ? found.First() : null;
+        }
+
+        [System.Web.Http.HttpGet]
         public object GetContentTypeIcon([System.Web.Http.ModelBinding.ModelBinder] Guid guid)
         {
             var contentTypeAlias = Services.ContentTypeService.GetAliasByGuid(guid);

--- a/Src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Config/grid.editors.config.js
+++ b/Src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Config/grid.editors.config.js
@@ -1,15 +1,29 @@
 ﻿{
-	"name": "Doc Type",
-	"alias": "docType",
-	"view": "/App_Plugins/DocTypeGridEditor/Views/doctypegrideditor.html",
-	"render": "/App_Plugins/DocTypeGridEditor/Render/DocTypeGridEditor.cshtml",
-	"icon": "icon-item-arrangement",
-	"config": {
-	    "allowedDocTypes": [],
+    "name": "Doc Type",
+    "alias": "docType",
+    "view": "/App_Plugins/DocTypeGridEditor/Views/doctypegrideditor.html",
+    "render": "/App_Plugins/DocTypeGridEditor/Render/DocTypeGridEditor.cshtml",
+    "icon": "icon-item-arrangement",
+    "config": {
+        "allowedDocTypes": [],
         "enablePreview": true,
         "viewPath": "/Views/Partials/Grid/Editors/DocTypeGridEditor/",
         "previewViewPath": "/Views/Partials/Grid/Editors/DocTypeGridEditor/Previews/",
         "previewCssFilePath": "/Views/Partials/Grid/Editors/DocTypeGridEditor/Previews/Css/dtge.css",
         "previewJsFilePath": "/Views/Partials/Grid/Editors/DocTypeGridEditor/Previews/Js/dtge.js"
-	}
+    }
+},{
+    "name": "DocTypeName",
+    "alias": "docTypeAlias",
+    "view": "/App_Plugins/DocTypeGridEditor/Views/doctypegrideditor.html",
+    "render": "/App_Plugins/DocTypeGridEditor/Render/DocTypeGridEditor.cshtml",
+    "icon": "icon-item-arrangement",
+    "config": {
+    	"isDocType": true,
+        "enablePreview": true,
+        "viewPath": "/Views/Partials/Grid/Editors/DocTypeGridEditor/",
+        "previewViewPath": "/Views/Partials/Grid/Editors/DocTypeGridEditor/Previews/",
+        "previewCssFilePath": "/Views/Partials/Grid/Editors/DocTypeGridEditor/Previews/Css/dtge.css",
+        "previewJsFilePath": "/Views/Partials/Grid/Editors/DocTypeGridEditor/Previews/Js/dtge.js"
+    }
 }

--- a/Src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
+++ b/Src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
@@ -78,7 +78,16 @@
         }
 
         $timeout(function () {
-            if ($scope.control.$initializing) {
+            if ($scope.control.editor.config.isDocType && $scope.control.value.docType == "") {
+                var result = dtgeResources.getContentType($scope.control.editor.alias);
+                result.then(function (data) {
+                    if (data != null) {
+                        $scope.control.value.docType = data.guid;
+                        $scope.control.value.value = null;
+                        $scope.setDocType();
+                    }
+                });
+            } else if ($scope.control.$initializing) {
                 $scope.setDocType();
             } else if ($scope.control.value) {
                 $scope.setPreview($scope.control.value);

--- a/Src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.resources.js
+++ b/Src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.resources.js
@@ -20,6 +20,13 @@
                     'Failed to retrieve content types'
                 );
             },
+            getContentType: function (alias) {
+                var url = "/umbraco/backoffice/DocTypeGridEditorApi/DocTypeGridEditorApi/GetContentType?alias=" + alias;
+                return umbRequestHelper.resourcePromise(
+                    $http.get(url),
+                    'Failed to retrieve content types'
+                );
+            },
             getContentTypeIcon: function (guid) {
                 var url = "/umbraco/backoffice/DocTypeGridEditorApi/DocTypeGridEditorApi/GetContentTypeIcon?guid=" + guid;
                 return umbRequestHelper.resourcePromise(


### PR DESCRIPTION
We've planed to replace all given controls with doctypes. But there are to many steps to get to the doctype dialog.

- click on PLUS (+)
- choose doctype
- open dropdown
- select doctype

So i added the possibility to add doctypes to the controlbox. You just have to add the definiton to the `grid.editors.js`. 

``` JavaScript
{
  	"name": "Tile",
  	"alias": "tile",
  	"view": "/App_Plugins/DocTypeGridEditor/Views/doctypegrideditor.html",
  	"render": "/App_Plugins/DocTypeGridEditor/Render/DocTypeGridEditor.cshtml",
  	"icon": "icon-item-arrangement",
  	"config": {
		"isDocType": true, // <= key is here
  		"enablePreview": true,
  		"viewPath": "/Views/Partials/"
  	}
}
```

I've planned to create some logic which adds all the allowedContentTypes to the `grid.editors.js`. You'll hear from me :grin:

Tobi
