### PR TITLE
Fixes empty control exception when a document type is not saved after…

### DIFF
--- a/Src/Our.Umbraco.DocTypeGridEditor/Helpers/DocTypeGridEditorHelper.cs
+++ b/Src/Our.Umbraco.DocTypeGridEditor/Helpers/DocTypeGridEditorHelper.cs
@@ -23,6 +23,9 @@ namespace Our.Umbraco.DocTypeGridEditor.Helpers
 
         public static IPublishedContent ConvertValueToContent(string id, string docTypeAlias, string dataJson)
         {
+            if (string.IsNullOrWhiteSpace(docTypeAlias))
+                return null;
+
             return (IPublishedContent)ApplicationContext.Current.ApplicationCache.RequestCache.GetCacheItem(
                 "DocTypeGridEditorHelper.ConvertValueToContent_" + id + "_" + docTypeAlias, () =>
                 {


### PR DESCRIPTION
… adding a cell

Steps to reproduce exception:

- Choose a layout
- Add an element
- Select any DTGE element
- Choose the Cancel button

A layout should then contain an empty cell which holds no data due to the document type instance not being saved. When rendering the grid on a page template, the following change is required as the `docTypeAlias` parameter is empty.

I'm not sure whether the issue is related to the grid or the DTGE but the change proposed appears to fix the issue.