### PR TITLE
#15: Use CompositionPropertyTypes instead of PropertyTypes

### DIFF
--- a/Src/Our.Umbraco.DocTypeGridEditor/Helpers/DocTypeGridEditorHelper.cs
+++ b/Src/Our.Umbraco.DocTypeGridEditor/Helpers/DocTypeGridEditorHelper.cs
@@ -63,7 +63,7 @@ namespace Our.Umbraco.DocTypeGridEditor.Helpers
                                 /* Now that we have the DB stored value, we actually need to then convert it into it's
                                  * XML serialized state as expected by the published property by calling ConvertDbToString
                                  */
-                                var propType2 = contentType.PropertyTypes.Single(x => x.Alias == propType.PropertyTypeAlias);
+                                var propType2 = contentType.CompositionPropertyTypes.Single(x => x.Alias == propType.PropertyTypeAlias);
                                 var newValue2 = propEditor.ValueEditor.ConvertDbToString(new Property(propType2, newValue), propType2, 
                                     ApplicationContext.Current.Services.DataTypeService);
 


### PR DESCRIPTION
This allows the use of document type compositions in Doc Type Grid Editor