### PR TITLE
Issue #28 - patch to stop exception shown to visitors

### DIFF
--- a/Src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Render/DocTypeGridEditor.cshtml
+++ b/Src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Render/DocTypeGridEditor.cshtml
@@ -11,7 +11,10 @@
     string viewPath = Model.editor.config.viewPath.ToString();
     string previewViewPath = Model.editor.config.previewViewPath.ToString();
     
-    var content = DocTypeGridEditorHelper.ConvertValueToContent(id, docType, value);
-
-    @Html.RenderDocTypeGridEditorItem(content, viewPath, previewViewPath)
+    if(docType != "")
+    { 
+        var content = DocTypeGridEditorHelper.ConvertValueToContent(id, docType, value);
+    
+        @Html.RenderDocTypeGridEditorItem(content, viewPath)
+    }
 }         


### PR DESCRIPTION
If the editor doesn't select a doc type then an exception is shown.
Quick trap if no doctype then don't render.