### PR TITLE
Re-enable NuGet package generation

### DIFF
--- a/build/install.ps1
+++ b/build/install.ps1
@@ -1,0 +1,19 @@
+param($installPath, $toolsPath, $package, $project)
+
+$appPluginsFolder = $project.ProjectItems | Where-Object { $_.Name -eq "App_Plugins" }
+$docTypeGridEditorFolder = $appPluginsFolder.ProjectItems | Where-Object { $_.Name -eq "DocTypeGridEditor" }
+
+if (!$docTypeGridEditorFolder)
+{
+	$newPackageFiles = "$installPath\Content\App_Plugins\DocTypeGridEditor"
+
+	$projFile = Get-Item ($project.FullName)
+	$projDirectory = $projFile.DirectoryName
+	$projectPath = Join-Path $projDirectory -ChildPath "App_Plugins"
+	$projectPathExists = Test-Path $projectPath
+
+	if ($projectPathExists) {	
+		Write-Host "Updating Nested Content App_Plugin files using PS as they have been excluded from the project"
+		Copy-Item $newPackageFiles $projectPath -Recurse -Force
+	}
+}

--- a/build/package.proj
+++ b/build/package.proj
@@ -123,6 +123,8 @@
 			<PluginFiles Include="$(CoreProjectDir)\Web\UI\**\*.*" />
 			<PackageFile Include="$(MSBuildProjectDirectory)\package.xml" />
 			<NuSpecFile Include="$(MSBuildProjectDirectory)\package.nuspec" />
+			<NugetReadme Include="$(MSBuildProjectDirectory)\Readme.txt" />
+			<InstallPsFile Include="$(MSBuildProjectDirectory)\install.ps1" />
 		</ItemGroup>
 		<Copy SourceFiles="@(BinFiles)" DestinationFolder="$(BuildUmbDir)\bin" />
 		<Copy SourceFiles="@(PackageFile)" DestinationFolder="$(BuildUmbDir)" />
@@ -132,6 +134,8 @@
 		<Copy SourceFiles="@(PluginFiles)" DestinationFiles="@(PluginFiles->'$(BuildNuGetDir)\Content\%(RecursiveDir)%(Filename)%(Extension)')" />
 		<Copy SourceFiles="@(SrcFiles)" DestinationFiles="@(SrcFiles->'$(BuildNuGetDir)\src\%(RecursiveDir)%(Filename)%(Extension)')" />
 		<Copy SourceFiles="@(NuSpecFile)" DestinationFolder="$(BuildNuGetDir)" />
+		<Copy SourceFiles="@(NugetReadme)" DestinationFolder="$(BuildNuGetDir)" />
+		<Copy SourceFiles="@(InstallPsFile)" DestinationFolder="$(BuildNuGetDir)\tools" />
 	</Target>
 
 	<!-- MANIFEST UMBRACO -->
@@ -191,12 +195,12 @@
 			OutputDirectory="$(ArtifactsDir)"
 			Files="@(PackageFiles)" />
 
-		<!--<MSBuild.NuGet.Tasks.Pack NuGetExePath="$(RootDir)\src\.nuget\NuGet.exe"
+		<MSBuild.NuGet.Tasks.Pack NuGetExePath="$(RootDir)\src\.nuget\NuGet.exe"
 			ManifestFile="$(BuildNuGetDir)\package.nuspec"
 			BasePath="$(BuildNuGetDir)"
 			Version="$(ProductVersion)"
 			OutputDirectory="$(ArtifactsDir)"
-			Symbols="true" />-->
+			Symbols="true" />
 
 		<RemoveDir Directories="$(BuildUmbDir)" Condition="Exists('$(BuildUmbDir)')" />
 		<RemoveDir Directories="$(BuildNuGetDir)" Condition="Exists('$(BuildNuGetDir)')" />

--- a/build/readme.txt
+++ b/build/readme.txt
@@ -1,0 +1,27 @@
+  ____            _____                  ____      _     _ _____    _ _ _             
+ |  _ \  ___   __|_   _|   _ _ __   ___ / ___|_ __(_) __| | ____|__| (_) |_ ___  _ __ 
+ | | | |/ _ \ / __|| || | | | '_ \ / _ \ |  _| '__| |/ _` |  _| / _` | | __/ _ \| '__|
+ | |_| | (_) | (__ | || |_| | |_) |  __/ |_| | |  | | (_| | |__| (_| | | || (_) | |   
+ |____/ \___/ \___||_| \__, | .__/ \___|\____|_|  |_|\__,_|_____\__,_|_|\__\___/|_|   
+                       |___/|_|                                                       
+
+--------------------------------------------------------------------------------------
+
+To enable DocTypeGridEditor you must add the following JSON snippet to grid.editors.config.js found in the Config folder
+
+{
+	"name": "Doc Type",
+	"alias": "docType",
+	"view": "/App_Plugins/DocTypeGridEditor/Views/doctypegrideditor.html",
+	"render": "/App_Plugins/DocTypeGridEditor/Render/DocTypeGridEditor.cshtml",
+	"icon": "icon-item-arrangement",
+	"config": {
+	    "allowedDocTypes": [],
+        "nameTemplate": "",
+        "enablePreview": true,
+        "viewPath": "/Views/Partials/Grid/Editors/DocTypeGridEditor/",
+        "previewViewPath": "/Views/Partials/Grid/Editors/DocTypeGridEditor/Previews/",
+        "previewCssFilePath": "/Views/Partials/Grid/Editors/DocTypeGridEditor/Previews/Css/dtge.css",
+        "previewJsFilePath": "/Views/Partials/Grid/Editors/DocTypeGridEditor/Previews/Js/dtge.js"
+	}
+}

--- a/src/Our.Umbraco.DocTypeGridEditor.sln
+++ b/src/Our.Umbraco.DocTypeGridEditor.sln
@@ -22,9 +22,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build Package", "Build Pack
 		..\appveyor.yml = ..\appveyor.yml
 		..\build-appveyor.cmd = ..\build-appveyor.cmd
 		..\build.cmd = ..\build.cmd
+		..\build\install.ps1 = ..\build\install.ps1
 		..\build\package.nuspec = ..\build\package.nuspec
 		..\build\package.proj = ..\build\package.proj
 		..\build\package.xml = ..\build\package.xml
+		..\build\readme.txt = ..\build\readme.txt
 	EndProjectSection
 EndProject
 Global


### PR DESCRIPTION
I have added a readme.txt containing the JSON snippet that needs to be manually added to grid.editors.config.js post NuGet package. This is due to the config overwrite issue discussed on Gitter.