### PR TITLE
Allow SurfaceController method names to use whatever case pleases them

### DIFF
--- a/src/Our.Umbraco.DocTypeGridEditor/Web/Extensions/UmbracoHelperExtensions.cs
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/Extensions/UmbracoHelperExtensions.cs
@@ -43,13 +43,13 @@ namespace Our.Umbraco.DocTypeGridEditor.Web.Extensions
                     foreach (var method in ctrlInstance.GetType().GetMethods(BindingFlags.Public | BindingFlags.Instance)
                         .Where(x => typeof(ActionResult).IsAssignableFrom(x.ReturnType)))
                     {
-                        if (method.Name == actionName)
+                        if (method.Name.InvariantEquals(actionName))
                         {
                             return true;
                         }
 
                         var attr = method.GetCustomAttribute<ActionNameAttribute>();
-                        if (attr != null && attr.Name == actionName)
+                        if (attr != null && attr.Name.InvariantEquals(actionName))
                         {
                             return true;
                         }


### PR DESCRIPTION
e.g. I like to use GridImageFullWidth but someone else might want to use gridImageFullWidth